### PR TITLE
Add new intel oneapi compilers from upstream develop branch

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -11,6 +11,17 @@ from spack.package import *
 
 versions = [
     {
+        "version": "2025.1.1",
+        "cpp": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh",
+            "sha256": "63ea61f54a5ea9d30059ea499697e04953915ef317c0e8fc457077b690c726df",
+        },
+        "ftn": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0e4735b3-8721-422b-b204-00eefe413bfd/intel-fortran-compiler-2025.1.1.10_offline.sh",
+            "sha256": "c59060a5b959fb0faeb1cde349689086da41d491adb41fd6c97177fcf59bf957",
+        },
+    },
+    {
         "version": "2025.1.0",
         "cpp": {
             "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh",

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -11,6 +11,17 @@ from spack.package import *
 
 versions = [
     {
+        "version": "2025.1.0",
+        "cpp": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh",
+            "sha256": "53489afcc9534e30ad807e94b158abfccf6a7eb3658f59655122d92fbad8fa72",
+        },
+        "ftn": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/577ebc28-d0f6-492b-9a43-b04354ce99da/intel-fortran-compiler-2025.1.0.601_offline.sh",
+            "sha256": "27016329dede8369679f22b4e9f67936837ce7972a1ef4f5c76ee87d7c963c81",
+        },
+    },
+    {
         "version": "2025.0.4",
         "cpp": {
             "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/84c039b6-2b7d-4544-a745-3fcf8afd643f/intel-dpcpp-cpp-compiler-2025.0.4.20_offline.sh",


### PR DESCRIPTION
### Testing
```
[root@b7bfa5061dd0 spack]# spack install intel-oneapi-compilers@2025.1.0
[+] /usr (external glibc-2.28-6bfinv7zwwffcz4l7b4cb6ndkdy77yqv)
[+] /opt/release/linux-rocky8-x86_64/gcc-8.5.0/gcc-runtime-8.5.0-xvjgomg5sceyxwzzma4lejwdhh4lp7xe
==> Installing intel-oneapi-compilers-2025.1.0-uxaugw3g3y3jpnunkqrpekmjf2zgmpfr [3/3]
==> No binary for intel-oneapi-compilers-2025.1.0-uxaugw3g3y3jpnunkqrpekmjf2zgmpfr found: installing from source
==> Fetching https://registrationcenter-download.intel.com/akdlm/IRC_NAS/cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh
==> Fetching https://registrationcenter-download.intel.com/akdlm/IRC_NAS/577ebc28-d0f6-492b-9a43-b04354ce99da/intel-fortran-compiler-2025.1.0.601_offline.sh
==> Moving resource stage
	source: /tmp/root/spack-stage/resource-fortran-installer-uxaugw3g3y3jpnunkqrpekmjf2zgmpfr/spack-src/
	destination: /tmp/root/spack-stage/spack-stage-intel-oneapi-compilers-2025.1.0-uxaugw3g3y3jpnunkqrpekmjf2zgmpfr/spack-src/fortran-installer
==> No patches needed for intel-oneapi-compilers
==> intel-oneapi-compilers: Executing phase: 'install'
==> intel-oneapi-compilers: Successfully installed intel-oneapi-compilers-2025.1.0-uxaugw3g3y3jpnunkqrpekmjf2zgmpfr
  Stage: 2m 12.91s.  Install: 1m 18.85s.  Post-install: 2.27s.  Total: 3m 34.04s
[+] /opt/release/linux-rocky8-x86_64_v3/gcc-8.5.0/intel-oneapi-compilers-2025.1.0-uxaugw3g3y3jpnunkqrpekmjf2zgmpfr

[root@b7bfa5061dd0 opt]# spack install intel-oneapi-compilers@2025.1.1
[+] /usr (external glibc-2.28-6bfinv7zwwffcz4l7b4cb6ndkdy77yqv)
[+] /opt/release/linux-rocky8-x86_64/gcc-8.5.0/gcc-runtime-8.5.0-xvjgomg5sceyxwzzma4lejwdhh4lp7xe
==> Installing intel-oneapi-compilers-2025.1.1-cceqteecvykqspkbvyvwtldwgxw7yzto [3/3]
==> No binary for intel-oneapi-compilers-2025.1.1-cceqteecvykqspkbvyvwtldwgxw7yzto found: installing from source
==> Fetching https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh
==> Fetching https://registrationcenter-download.intel.com/akdlm/IRC_NAS/0e4735b3-8721-422b-b204-00eefe413bfd/intel-fortran-compiler-2025.1.1.10_offline.sh
==> Moving resource stage
	source: /tmp/root/spack-stage/resource-fortran-installer-cceqteecvykqspkbvyvwtldwgxw7yzto/spack-src/
	destination: /tmp/root/spack-stage/spack-stage-intel-oneapi-compilers-2025.1.1-cceqteecvykqspkbvyvwtldwgxw7yzto/spack-src/fortran-installer
==> No patches needed for intel-oneapi-compilers
==> intel-oneapi-compilers: Executing phase: 'install'
==> intel-oneapi-compilers: Successfully installed intel-oneapi-compilers-2025.1.1-cceqteecvykqspkbvyvwtldwgxw7yzto
  Stage: 22.54s.  Install: 1m 26.29s.  Post-install: 2.21s.  Total: 1m 51.07s
[+] /opt/release/linux-rocky8-x86_64_v3/gcc-8.5.0/intel-oneapi-compilers-2025.1.1-cceqteecvykqspkbvyvwtldwgxw7yzto

[root@b7bfa5061dd0 opt]# spack load intel-oneapi-compilers@2025.1.1
[root@b7bfa5061dd0 opt]# spack compiler find
==> Added 1 new compiler to /opt/spack/etc/spack/linux/compilers.yaml
    oneapi@2025.1.1
==> Compilers are defined in the following files:
    /opt/spack/etc/spack/linux/compilers.yaml

[om2] [root@b7bfa5061dd0 opt]# spack install

[om2] [root@b7bfa5061dd0 spack]# spack find cice5@git.2025.03.001=access-om2 %oneapi@2025.1.1
==> In environment om2
==> 1 root specs
 -  access-om2@git.2025.03.001=latest

==> Installed packages
-- linux-rocky8-x86_64 / oneapi@2025.1.1 ------------------------
cice5@git.2025.03.001=access-om2
```