### PR TITLE
intel-oneapi-compilers: add new intel-oneapi packages

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -11,6 +11,17 @@ from spack.package import *
 
 versions = [
     {
+        "version": "2025.2.0",
+        "cpp": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/39c79383-66bf-4f44-a6dd-14366e34e255/intel-dpcpp-cpp-compiler-2025.2.0.527_offline.sh",
+            "sha256": "aea3c1ccb97728db138b4f11f771411264292ba7bbec313782229510c9b831bc",
+        },
+        "ftn": {
+            "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2c69ab6a-dfff-4d8f-ae1c-8368c79a1709/intel-fortran-compiler-2025.2.0.534_offline.sh",
+            "sha256": "3808000bbcef15f17b608156b956e0114393a1b64ee6d9fb29be06450fa40083",
+        },
+    },
+    {
         "version": "2025.1.1",
         "cpp": {
             "url": "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c4d2aef3-3123-475e-800c-7d66fd8da2a5/intel-dpcpp-cpp-compiler-2025.1.1.9_offline.sh",


### PR DESCRIPTION
* Cherry-picked upstream commit d768946796d929943a39035ae89fb5fb0056be2f to var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py