### PR TITLE
Add openssh versions

### DIFF
--- a/var/spack/repos/builtin/packages/openssh/package.py
+++ b/var/spack/repos/builtin/packages/openssh/package.py
@@ -25,6 +25,11 @@ class Openssh(AutotoolsPackage):
 
     license("SSH-OpenSSH")
 
+    version("10.0p2", sha256="021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c")
+    version("10.0p1", sha256="021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c")
+    version("9.9p2", sha256="91aadb603e08cc285eddf965e1199d02585fa94d994d6cae5b41e1721e215673")
+    version("9.9p1", sha256="b343fbcdbff87f15b1986e6e15d6d4fc9a7d36066be6b7fb507087ba8f966c02")
+    version("9.8p1", sha256="dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3")
     version("9.7p1", sha256="490426f766d82a2763fcacd8d83ea3d70798750c7bd2aff2e57dc5660f773ffd")
     version("9.6p1", sha256="910211c07255a8c5ad654391b40ee59800710dd8119dd5362de09385aa7a777c")
     version("9.5p1", sha256="f026e7b79ba7fb540f75182af96dc8a8f1db395f922bbc9f6ca603672686086b")


### PR DESCRIPTION
## Overview
Added newer versions of Openssh package for [ACCESS-NRI/system-tools issue #5](https://github.com/ACCESS-NRI/system-tools/issues/5).

The checksums were obtained using the [`spack checksum`](https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#automatically-adding-new-versions) command.