### PR TITLE
openmpi: add the latest versions available on Gadi

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -64,6 +64,9 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         "5.0.0", sha256="9d845ca94bc1aeb445f83d98d238cd08f6ec7ad0f73b0f79ec1668dbfdacd613"
     )  # libmpi.so.40.40.0
     version(
+        "4.1.7", sha256="54a33cb7ad81ff0976f15a6cc8003c3922f0f3d8ceed14e1813ef3603f22cd34"
+    )  # libmpi.so.40.30.7
+    version(
         "4.1.6", sha256="f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415"
     )  # libmpi.so.40.30.6
     version(

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -44,10 +44,16 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
     # Current
     version(
-        "5.0.3", sha256="990582f206b3ab32e938aa31bbf07c639368e4405dca196fabe7f0f76eeda90b"
-    )  # libmpi.so.40.40.3
+        "5.0.5", sha256="6588d57c0a4bd299a24103f4e196051b29e8b55fbda49e11d5b3d32030a32776"
+    )  # libmpi.so.40.40.5
 
     # Still supported
+    version(
+        "5.0.4", sha256="64526852cdd88b2d30e022087c16ab3e03806c451b10cd691d5c1ac887d8ef9d"
+    )  # libmpi.so.40.40.4
+    version(
+        "5.0.3", sha256="990582f206b3ab32e938aa31bbf07c639368e4405dca196fabe7f0f76eeda90b"
+    )  # libmpi.so.40.40.3
     version(
         "5.0.2", sha256="ee46ad8eeee2c3ff70772160bff877cbf38c330a0bc3b3ddc811648b3396698f"
     )  # libmpi.so.40.40.2


### PR DESCRIPTION
### Testing

```
[root@1a125f903e22 spack]# spack install openmpi@4.1.7 %intel@2021.10.0 target=x86_64
...
==> Installing openmpi-4.1.7-f2an26j36gwh7jrgqygp5ktpobyzmthx [25/25]
==> No binary for openmpi-4.1.7-f2an26j36gwh7jrgqygp5ktpobyzmthx found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/54/54a33cb7ad81ff0976f15a6cc8003c3922f0f3d8ceed14e1813ef3603f22cd34.tar.bz2
==> No patches needed for openmpi
==> openmpi: Executing phase: 'autoreconf'
==> openmpi: Executing phase: 'configure'
==> openmpi: Executing phase: 'build'
==> openmpi: Executing phase: 'install'
==> openmpi: Successfully installed openmpi-4.1.7-f2an26j36gwh7jrgqygp5ktpobyzmthx
  Stage: 3.69s.  Autoreconf: 0.00s.  Configure: 2m 53.10s.  Build: 3m 5.59s.  Install: 47.78s.  Post-install: 0.29s.  Total: 6m 50.65s
[+] /opt/release/linux-rocky8-x86_64/intel-2021.10.0/openmpi-4.1.7-f2an26j36gwh7jrgqygp5ktpobyzmthx
```

```
[root@1a125f903e22 spack]# spack install openmpi@5.0.5 %intel@2021.10.0 target=x86_64
...
==> Installing openmpi-5.0.5-kc23wv6xe2nzjxohy2wmqj2xmjudhyvg [31/31]
==> No binary for openmpi-5.0.5-kc23wv6xe2nzjxohy2wmqj2xmjudhyvg found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/65/6588d57c0a4bd299a24103f4e196051b29e8b55fbda49e11d5b3d32030a32776.tar.bz2
==> No patches needed for openmpi
==> openmpi: Executing phase: 'autoreconf'
==> openmpi: Executing phase: 'configure'
==> openmpi: Executing phase: 'build'
==> openmpi: Executing phase: 'install'
==> openmpi: Successfully installed openmpi-5.0.5-kc23wv6xe2nzjxohy2wmqj2xmjudhyvg
  Stage: 7.65s.  Autoreconf: 0.00s.  Configure: 2m 8.53s.  Build: 3m 28.46s.  Install: 16.96s.  Post-install: 0.58s.  Total: 6m 2.34s
[+] /opt/release/linux-rocky8-x86_64/intel-2021.10.0/openmpi-5.0.5-kc23wv6xe2nzjxohy2wmqj2xmjudhyvg
```